### PR TITLE
Iterator module

### DIFF
--- a/Slakefile
+++ b/Slakefile
@@ -9,11 +9,12 @@ require! {
 
 pkg = JSON.parse cat 'package.json'
 
-sources =
-  \head.ls
-  \emoji.ls
-  \linkify.ls
-  \index.ls
+sources = <[
+  head.ls
+  emoji.ls
+  linkify.ls
+  index.ls
+]>
 
 if not test \-d \vendor
    mkdir \vendor
@@ -23,7 +24,7 @@ task \bundle 'Bundle dependencies.' !->
   b = browserify!
   b.require \marked
   b.require \highlight.js
-  (err, deps) <-! b.bundle {}
+  err, deps <-! b.bundle {}
   deps.to 'vendor.js'
   console.log 'Dependencies built successfully!'
 

--- a/Slakefile
+++ b/Slakefile
@@ -12,6 +12,7 @@ pkg = JSON.parse cat 'package.json'
 sources = <[
   head.ls
   emoji.ls
+  iterator.ls
   linkify.ls
   index.ls
 ]>

--- a/src/iterator.ls
+++ b/src/iterator.ls
@@ -2,6 +2,7 @@ Iterator = let
     
   iterator = (text, regex, fn, ret = '') ->
     start = len = 0
+    skip = false
     while test = regex.exec text
       start += len
       if start > test.index
@@ -13,14 +14,24 @@ Iterator = let
         len = test.index - start + test.0.length
         current = text.substr start, len
         rest = text.substr start + len
-        skip = current.match /`/g
-        if skip and skip.length .&. 1
-          skip = true
-          stop = (/`|```/ == rest)
-          len += (stop?index + stop?0.length) or rest.length
-          current = text.substr start, len
-          rest = text.substr start + len
+        
+        backtick-skip = current.match /`/g
+        if backtick-skip and backtick-skip.length .&. 1
+          if stop = (/`|```/ == rest)
+            skip = true
+            len += stop.index + stop.0.length
+            current = text.substr start, len
+            rest = text.substr start + len
         else skip = false
+
+        indent-skip = current.match /\n {4}|\n\t/g
+        if indent-skip
+          if stop = (/\n[^ \t]{1,4}/ == rest)
+            skip = true
+            len += stop.index
+            current = text.substr start, len
+            rest = text.substr start + len
+
       
       ret += skip and current or current.replace test.0, fn test
 

--- a/src/iterator.ls
+++ b/src/iterator.ls
@@ -22,7 +22,7 @@ Iterator = let
           rest = text.substr start + len
         else skip = false
       
-      ret += fn current, that unless skip
+      ret += skip and current or fn current, that
 
     if not ret then text
     else ret + rest

--- a/src/iterator.ls
+++ b/src/iterator.ls
@@ -49,6 +49,10 @@ Iterator = let
         # transformation is skipped and we figure out where the code block
         # ends and only transform matches after that.
         #
+        # If you want to know why bitwise AND 1 is used instead of modulo 2,
+        # it's because the former is consistently faster:
+        # http://jsperf.com/modulo-vs-bitwise-and-for-odd-checking
+        #
         # The indent check is much simpler in comparison - it simply figures
         # out if the line of the match is indented with at least 4 spaces
         # or a single tab. If it is, the match transformation is skipped once

--- a/src/iterator.ls
+++ b/src/iterator.ls
@@ -2,7 +2,7 @@ Iterator = let
     
   iterator = (text, regex, fn, ret = '') ->
     start = len = 0
-    while regex.exec text
+    while test = regex.exec text
       start += len
       if start > test.index
         len = 0
@@ -10,7 +10,7 @@ Iterator = let
         current = ''
         rest = text.substr start
       else
-        len = test.index - start + matched.length
+        len = test.index - start + test.0.length
         current = text.substr start, len
         rest = text.substr start + len
         skip = current.match /`/g
@@ -22,10 +22,10 @@ Iterator = let
           rest = text.substr start + len
         else skip = false
       
-      ret += skip and current or fn current, that
+      ret += skip and current or current.replace test.0, fn test
 
     if not ret then text
     else ret + rest
 
-  module?exports = linkify
-  linkify
+  module?exports = iterator
+  iterator

--- a/src/iterator.ls
+++ b/src/iterator.ls
@@ -1,19 +1,59 @@
+# Iterator module
+# ===============
+# This module provides the "iterator" function. The input `text` should be
+# raw markdown. The `regex` should be a global regular expression (with or
+# without capture groups). The iterator will find all the regex matches
+# in the text and transform them with the given function `fn` - unless the
+# match is inside a code block (marked with backticks or indents).
+# The transform function is passed the regex match result object, which has
+# the form [match, capture groups, index: n, input: text]. `ret` is the
+# transformed text that will be returned at the end, and the user should
+# not provide any value for this argument (unless they want the whole text
+# to be prepended with it). 
+
 Iterator = let
     
   iterator = (text, regex, fn, ret = '') ->
     start = len = 0
     skip = false
     while test = regex.exec text
+
       start += len
+
+      # If the previous match was inside a code span/block, the "text block"
+      # of the match was extended to the end of said block. If the start
+      # index is greater than the current match index, it means there were
+      # multiple matches inside a single code block and thus any matches
+      # should be skipped until we're out of the code block.
+
       if start > test.index
         len = 0
         skip = true
         current = ''
         rest = text.substr start
       else
+
+        # `current` is a string extending from the end of the last match
+        # to the end of the current match. `rest` is simply the rest of the
+        # text after the end of the current match. It is used to return any
+        # text left over after the final match.
+
         len = test.index - start + test.0.length
         current = text.substr start, len
         rest = text.substr start + len
+
+        # The following code figures out if the current match is inside a
+        # code block or not. In case of backticks, we're counting the amount
+        # of backticks and seeing if it's odd or not - if it is, then it
+        # means a code block is 'open' and we're inside it. The match
+        # transformation is skipped and we figure out where the code block
+        # ends and only transform matches after that.
+        #
+        # The indent check is much simpler in comparison - it simply figures
+        # out if the line of the match is indented with at least 4 spaces
+        # or a single tab. If it is, the match transformation is skipped once
+        # again and we find the first line with no 'code indentation' and
+        # only transform matches after that. 
         
         backtick-skip = current.match /`/g
         if backtick-skip and backtick-skip.length .&. 1
@@ -32,11 +72,22 @@ Iterator = let
             current = text.substr start, len
             rest = text.substr start + len
 
+      # Here we append the return string. If `skip` is true, we simply add
+      # the current text block as-is, but if it's not, we transform the match
+      # in the text block using the user-provided function. 
       
       ret += skip and current or current.replace test.0, fn test
 
+    # if there were no matches to the given regex, ret will be empty.
+    # In this case, we simply return the original text.
+    # Otherwise, we return the transformed text.
+
     if not ret then text
     else ret + rest
+
+  # if this file is required as a module in node.js, the iterator function
+  # is exported as the module contents. Beyond that, we return the iterator
+  # function so that it will be available in the top-level Iterator variable.
 
   module?exports = iterator
   iterator

--- a/src/iterator.ls
+++ b/src/iterator.ls
@@ -12,6 +12,9 @@
 # to be prepended with it). 
 
 Iterator = let
+
+  reverse = ->
+    it.split '' .reverse!join ''
     
   iterator = (text, regex, fn, ret = '') ->
     start = len = 0
@@ -68,13 +71,16 @@ Iterator = let
             rest = text.substr start + len
         else skip = false
 
-        indent-skip = current.match /\n {4}|\n\t/g
-        if indent-skip
+        indent-skip = current.split '\n'
+        if /^ {4}|^\t/ == indent-skip[*-1]
+          skip = true
           if stop = (/\n[^ \t]{1,4}/ == rest)
-            skip = true
             len += stop.index
-            current = text.substr start, len
-            rest = text.substr start + len
+          else
+            len += rest.length
+          current = text.substr start, len
+          rest = text.substr start + len
+
 
       # Here we append the return string. If `skip` is true, we simply add
       # the current text block as-is, but if it's not, we transform the match

--- a/src/iterator.ls
+++ b/src/iterator.ls
@@ -1,0 +1,31 @@
+Iterator = let
+    
+  iterator = (text, regex, fn, ret = '') ->
+    start = len = 0
+    while regex.exec text
+      start += len
+      if start > test.index
+        len = 0
+        skip = true
+        current = ''
+        rest = text.substr start
+      else
+        len = test.index - start + matched.length
+        current = text.substr start, len
+        rest = text.substr start + len
+        skip = current.match /`/g
+        if skip and skip.length .&. 1
+          skip = true
+          stop = (/`|```/ == rest)
+          len += (stop?index + stop?0.length) or rest.length
+          current = text.substr start, len
+          rest = text.substr start + len
+        else skip = false
+      
+      ret += fn current, that unless skip
+
+    if not ret then text
+    else ret + rest
+
+  module?exports = linkify
+  linkify

--- a/src/linkify.ls
+++ b/src/linkify.ls
@@ -1,6 +1,6 @@
 Linkify = let
   
-  iterator = if module? then require \iterator else Iterator
+  iterator = if module? then require './iterator' else Iterator
 
   linkify =
     all: (text, context) ->
@@ -9,54 +9,29 @@ Linkify = let
       text = @mention text
   
     sha: (text, context, ret = '') ->
-      start = len = 0
       regex = /(?:([A-Za-z0-9-]*)(?:\/([A-Za-z0-9_-]*))?@)?([a-f0-9]{40})/g
-      while test = regex.exec text
-        [matched, user, repo, hash] = test
-        start += len
-        if start > test.index
-          len = 0
-          skip = true
-          current = ''
-          rest = text.substr start
-        else
-          len = test.index - start + matched.length
-          current = text.substr start, len
-          rest = text.substr start + len
-          skip = current.match /`/g
-          if skip and skip.length .&. 1
-            skip = true
-            stop = (/`|```/ == rest)
-            len += (stop?index + stop?0.length) or rest.length
-            current = text.substr start, len
-            rest = text.substr start + len
-          else skip = false
+      iterator text, regex, ->
+        [matched, user, repo, hash] = it
         short = hash.substr 0 8
         [ctx-user, ctx-repo] = context.split '/'
-        if (test.index > 0) and (text.char-at test.index - 1) is '/'
-          ret += current
-        else
-          ret += current.replace matched, switch
-            case skip
-              matched
-            case user and not repo
-              switch
-              | /\/@/ == matched  => "[#user/@`#short`](/#user//commit/#hash)"
-              | otherwise => "[#user@`#short`](/#user/#ctx-repo/commit/#hash)"
-            case user and repo
-              "[#user/#repo@`#short`](/#user/#repo/commit/#hash)"
-            case not user and not repo
-              switch (/^@|^\/@/ == matched)?0
-              | '@'  => "[@`#short`](/#context/commit/#hash)"
-              | '/@' => "/@[`#short`](/#context/commit/#hash)"
-              | _    => "[`#short`](/#context/commit/#hash)"
-            default
-              matched
-      if not ret then text
-      else ret + rest
+        if (it.index > 0) and (text.char-at it.index - 1) is '/'
+          matched
+        else switch
+          case user and not repo
+            switch
+            | /\/@/ == matched  => "[#user/@`#short`](/#user//commit/#hash)"
+            | otherwise => "[#user@`#short`](/#user/#ctx-repo/commit/#hash)"
+          case user and repo
+            "[#user/#repo@`#short`](/#user/#repo/commit/#hash)"
+          case not user and not repo
+            switch (/^@|^\/@/ == matched)?0
+            | '@'  => "[@`#short`](/#context/commit/#hash)"
+            | '/@' => "/@[`#short`](/#context/commit/#hash)"
+            | _    => "[`#short`](/#context/commit/#hash)"
+          default
+            matched
   
     issue: (text, context, ret = '') ->
-      start = len = 0
       regex = //
       (?:
         https:\/\/github.com\/
@@ -68,35 +43,15 @@ Linkify = let
         (?:\/([A-Za-z0-9_-]*))?)?
         \#([0-9]+)
       )//g
-      while test = regex.exec text
-        if (test.0.substr 0 5) == "https"
-          [matched, user, repo, number] = test
+      iterator text, regex, ->
+        if (it.0.substr 0 5) == \https
+          [matched, user, repo, number] = it
           url = true
         else
-          [matched, _, _, _, user, repo, number] = test
+          [matched, _, _, _, user, repo, number] = it
           url = false
-        start += len
-        if start > test.index
-          len = 0
-          skip = true
-          current = ''
-          rest = text.substr start
-        else
-          len = test.index - start + matched.length
-          current = text.substr start, len
-          rest = text.substr start + len
-          skip = current.match /`/g
-          if skip and skip.length .&. 1
-            skip = true
-            stop = (/`|```/ == rest)
-            len += (stop?index + stop?0.length) or rest.length
-            current = text.substr start, len
-            rest = text.substr start + len
-          else skip = false
         [ctx-user, ctx-repo] = context.split '/'
-        ret += current.replace matched, switch
-          case skip
-            matched
+        switch
           case user and not repo
             "[#user##number](/#user/#ctx-repo/issues/#number)"
           case user and repo and url
@@ -110,44 +65,19 @@ Linkify = let
             "[##number](/#context/issues/#number)"
           default
             matched
-      if not ret then text
-      else ret + rest
   
     mention: (text, ret = '') ->
-      start = len = 0
       regex = /([^A-Za-z0-9])@([A-Za-z0-9-]+)|^@([A-Za-z0-9-]+)/g
-      while test = regex.exec text
-        [matched, pre, n1, n2] = test
+      iterator text, regex, ->
+        [matched, pre, n1, n2] = it
         name = n1 or n2
         pre ?= ''
-        start += len
-        if start > test.index
-          len = 0
-          skip = true
-          current = ''
-          rest = text.substr start
-        else
-          len = test.index - start + matched.length
-          current = text.substr start, len
-          rest = text.substr start + len
-          skip = current.match /`/g
-          if skip and skip.length .&. 1
-            skip = true
-            stop = (/`|```/ == rest)
-            len += (stop?index + stop?0.length) or rest.length
-            current = text.substr start, len
-            rest = text.substr start + len
-          else skip = false
         if /[a-f0-9]{40}/ == name then skip = true
-        ret += current.replace matched, switch
-        case skip
-          matched
-        case name == \mention
-          "#pre<a class='user-mention' href='/blog/821'>@mention</a>"
-        default
-          "#pre<a class='user-mention' href='/#name'>@#name</a>"
-      if not ret then text
-      else ret + rest
+        switch
+          case name == \mention
+            "#pre<a class='user-mention' href='/blog/821'>@mention</a>"
+          default
+            "#pre<a class='user-mention' href='/#name'>@#name</a>"
 
   module?exports = linkify
   linkify

--- a/src/linkify.ls
+++ b/src/linkify.ls
@@ -1,4 +1,6 @@
 Linkify = let
+  
+  iterator = if module? then require \iterator else Iterator
 
   linkify =
     all: (text, context) ->

--- a/test/linkify.ls
+++ b/test/linkify.ls
@@ -86,6 +86,24 @@ suite \Linkify !->
         test
       """
 
+      (Linkify.sha """
+        test
+
+            test
+
+        d4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9
+
+            test
+        """ context).should.equal """
+        test
+
+            test
+
+        [`d4c58ff2`](/User/Test-Repo/commit/d4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9)
+
+            test
+      """
+
     test 'should not mangle code tags with multiple instances' !->
     (Linkify.sha """
       ```

--- a/test/linkify.ls
+++ b/test/linkify.ls
@@ -64,6 +64,28 @@ suite \Linkify !->
         ```
       """
 
+      (Linkify.sha """
+        test
+
+            d4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9
+
+        test
+
+            d4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9
+
+        test
+      """ context).should.equal """
+        test
+
+            d4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9
+
+        test
+
+            d4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9
+
+        test
+      """
+
     test 'should not mangle code tags with multiple instances' !->
     (Linkify.sha """
       ```

--- a/test/linkify.ls
+++ b/test/linkify.ls
@@ -71,7 +71,7 @@ suite \Linkify !->
 
         test
 
-            d4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9
+        \td4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9
 
         test
       """ context).should.equal """
@@ -81,7 +81,7 @@ suite \Linkify !->
 
         test
 
-            d4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9
+        \td4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9
 
         test
       """

--- a/test/linkify.ls
+++ b/test/linkify.ls
@@ -94,6 +94,10 @@ suite \Linkify !->
         d4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9
 
             test
+
+        d4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9
+
+        \ttest
         """ context).should.equal """
         test
 
@@ -102,6 +106,10 @@ suite \Linkify !->
         [`d4c58ff2`](/User/Test-Repo/commit/d4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9)
 
             test
+
+        [`d4c58ff2`](/User/Test-Repo/commit/d4c58ff2cd197dc2e53e4d1fee1ca4332fdda5d9)
+
+        \ttest
       """
 
     test 'should not mangle code tags with multiple instances' !->


### PR DESCRIPTION
There was a lot of repeated code in the linkifier when it came to iterating over the base text, so I decided to separate it into another module called `iterator`. This pull request adds said class and makes the linkifier use it, as well as adds support for indented code blocks (with either four spaces or tabs).
