### PR TITLE
Tipsy module

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -74,3 +74,27 @@ License for Elusive follows:
   Author:    Aristeides Stathopoulos
   License:   SIL (http://scripts.sil.org/OFL)
   Homepage:  http://aristeides.com/
+
+License for Tipsy follows:
+
+  The MIT License
+
+  Copyright (c) 2008 Jason Frame (jason@onehackoranother.com)
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -75,7 +75,7 @@ License for Elusive follows:
   License:   SIL (http://scripts.sil.org/OFL)
   Homepage:  http://aristeides.com/
 
-License for Tipsy follows:
+License for tipsy follows:
 
   The MIT License
 

--- a/Slakefile
+++ b/Slakefile
@@ -17,6 +17,7 @@ sources = <[
   linkify.ls
   emoji-list.ls
   emoji.ls
+  tipsy.ls
   index.ls
 ]>
 
@@ -53,13 +54,10 @@ task \build 'Build the userscript.' !->
   css = clean-css.process (cat 'style.css'), css-opts
   pre = clean-css.process (cat 'github.css'), css-opts
 
-  embed = 'https://gist.github.com/Daiz-/0146e783887fea4c462d/raw/fea70365ef1281e09959914a8c765efb2d5a1db8/embed.js'
-
   head  .= replace 'VERSION' pkg.version
   body = body
     .replace 'INLINE_CSS' css
     .replace 'INLINE_PRE_CSS' pre
-    .replace 'INLINE_JS' embed
 
   body = """
     (function(){

--- a/src/index.ls
+++ b/src/index.ls
@@ -55,19 +55,13 @@ css-pre = d.create-element \style
   ..class-name = \live-preview-code-styling
   ..text-content = \INLINE_PRE_CSS
 
-# create the script element
-js = d.create-element \script
-  ..src = \INLINE_JS
-
-# append initial elements to appropriate places
 head
   ..append-child css
   ..append-child css-pre
 
 button.append-child icon
 content.insert-before button, content.first-child
-
-d.body.append-child js
+Tipsy button
 
 # create preview element
 preview-bucket = d.query-selector \.preview-content

--- a/src/tipsy.ls
+++ b/src/tipsy.ls
@@ -1,23 +1,48 @@
 Tipsy = let
-	
-	d = document
+  
+  d = document
 
-	tipsy = (el, opts = gravity: \e, text: 'Live Preview') ->
-		
-		tip = d.create-element \div
-			..class-name = "tipsy tipsy-#{opts.gravity}"
-			..append-child d.create-element \div
-				..class-name = "tipsy-arrow tipsy-arrow-#{opts.gravity}"
-			..append-child d.create-element \div
-				..class-name = 'tipsy-inner'
-				..text-content = opts.text
-			..style
-				..opacity = 0.8
-				..visibility = hidden
+  default-opts =
+    gravity: \e
+    text: 'Live Preview'
+    offset: 0
+
+  tipsy = (el, opts = ^^default-opts) ->
+    
+    tip = d.create-element \div
+      ..class-name = "tipsy tipsy-#{opts.gravity}"
+      ..append-child d.create-element \div
+        ..class-name = "tipsy-arrow tipsy-arrow-#{opts.gravity}"
+      ..append-child d.create-element \div
+        ..class-name = 'tipsy-inner'
+        ..text-content = opts.text
+      ..style
+        ..opacity = 0.8
+        ..top = 0
+        ..left = 0
+        ..display = \none
+
+    d.body.append-child tip
+
+    el-top  = el.offset-top
+    el-left = el-offset-left
+
+    el-width  = el.offset-width
+    el-height = el.offset-height
+
+    tip-width  = tip.offset-width
+    tip-height = tip.offset-height 
+
+    pos = switch opts.gravity
+    | \n => top: el-top + el-height + opts.offset, left: el-left + el-width / 2 - tip-width / 2
+    | \s => top: el-top - tip-height - opts.offset, left: el-left + el-width / 2 - tip-width / 2
+    | \e => top: el-top + el-height / 2 - tip-height / 2, left: el-left - tip-width - opts.offset
+    | \w => top: el-top + el-height / 2 - tip-height / 2, left: el-left + el-width + opts.offset
+
+    tip.style
+      {..top, ..left} = pos
 
 
 
-
-
-	module?exports = tipsy
-	tipsy
+  module?exports = tipsy
+  tipsy

--- a/src/tipsy.ls
+++ b/src/tipsy.ls
@@ -1,3 +1,12 @@
+# Tipsy module
+# ============
+# This module is a very lightweight and stripped-down version of tipsy[1].
+# It provides a tooltip for the Live Preview button in the edit box in the
+# style of GitHub's other tooltips. Functionality can be extended in the
+# future if necessary.
+#
+# [1] https://github.com/jaz303/tipsy
+
 Tipsy = let
   
   d = document
@@ -19,7 +28,9 @@ Tipsy = let
     text: 'Live&nbsp;Preview'
     offset: 0
 
-  tipsy = (el, opts = ^^default-opts) !->
+  tipsy = !(el, opts = ^^default-opts) ->
+
+    # https://github.com/jaz303/tipsy/blob/master/src/javascripts/jquery.tipsy.js#L36-L58
     
     tip = d.create-element \div
       ..class-name = "tipsy tipsy-#{opts.gravity}"

--- a/src/tipsy.ls
+++ b/src/tipsy.ls
@@ -2,6 +2,16 @@ Tipsy = let
   
   d = document
 
+  show-tip = ->
+    el = it.target
+    tip = el.query-selector \.tipsy
+    tip.style.display = \block
+
+  hide-tip = ->
+    el = it.target
+    tip = el.query-selector \.tipsy
+    tip.style.display = \none
+
   default-opts =
     gravity: \e
     text: 'Live Preview'
@@ -22,7 +32,7 @@ Tipsy = let
         ..left = 0
         ..display = \none
 
-    d.body.append-child tip
+    el.append-child tip
 
     el-top  = el.offset-top
     el-left = el-offset-left
@@ -41,6 +51,9 @@ Tipsy = let
 
     tip.style
       {..top, ..left} = pos
+
+    el.add-event-listener \mouseover show-tip
+    el.add-event-listener \mouseout  hide-tip
 
 
 

--- a/src/tipsy.ls
+++ b/src/tipsy.ls
@@ -1,0 +1,23 @@
+Tipsy = let
+	
+	d = document
+
+	tipsy = (el, opts = gravity: \e, text: 'Live Preview') ->
+		
+		tip = d.create-element \div
+			..class-name = "tipsy tipsy-#{opts.gravity}"
+			..append-child d.create-element \div
+				..class-name = "tipsy-arrow tipsy-arrow-#{opts.gravity}"
+			..append-child d.create-element \div
+				..class-name = 'tipsy-inner'
+				..text-content = opts.text
+			..style
+				..opacity = 0.8
+				..visibility = hidden
+
+
+
+
+
+	module?exports = tipsy
+	tipsy

--- a/src/tipsy.ls
+++ b/src/tipsy.ls
@@ -2,19 +2,22 @@ Tipsy = let
   
   d = document
 
-  show-tip = ->
-    el = it.target
-    tip = el.query-selector \.tipsy
-    tip.style.display = \block
+  add-tip = ->
+    it.add-event-listener \mouseover show-tip
+    it.add-event-listener \mouseout  destroy-tip
 
-  hide-tip = ->
-    el = it.target
-    tip = el.query-selector \.tipsy
-    tip.style.display = \none
+  show-tip = ->
+    el = it.target.parent-node
+    console.log el
+    tip = tipsy el
+
+  destroy-tip = ->
+    tip = d.body.query-selector \.tipsy
+    d.body.remove-child tip
 
   default-opts =
     gravity: \e
-    text: 'Live Preview'
+    text: 'Live&nbsp;Preview'
     offset: 0
 
   tipsy = (el, opts = ^^default-opts) ->
@@ -25,23 +28,24 @@ Tipsy = let
         ..class-name = "tipsy-arrow tipsy-arrow-#{opts.gravity}"
       ..append-child d.create-element \div
         ..class-name = 'tipsy-inner'
-        ..text-content = opts.text
+        ..innerHTML = opts.text
       ..style
         ..opacity = 0.8
         ..top = 0
         ..left = 0
-        ..display = \none
+        ..display = \block
 
-    el.append-child tip
+    d.body.insert-before tip, d.body.first-child 
 
-    el-top  = el.offset-top
-    el-left = el-offset-left
+    el-rect = el.get-bounding-client-rect!
+    el-top  = el-rect.top + 1
+    el-left = el-rect.left
 
     el-width  = el.offset-width
     el-height = el.offset-height
 
     tip-width  = tip.offset-width
-    tip-height = tip.offset-height 
+    tip-height = tip.offset-height
 
     pos = switch opts.gravity
     | \n => top: el-top + el-height + opts.offset, left: el-left + el-width / 2 - tip-width / 2
@@ -49,13 +53,14 @@ Tipsy = let
     | \e => top: el-top + el-height / 2 - tip-height / 2, left: el-left - tip-width - opts.offset
     | \w => top: el-top + el-height / 2 - tip-height / 2, left: el-left + el-width + opts.offset
 
+    console.log el-top, el-left, el-width, el-height, tip-width, tip-height
+    console.log pos
+
     tip.style
-      {..top, ..left} = pos
+      ..top = pos.top + \px
+      ..left = pos.left + \px
 
-    el.add-event-listener \mouseover show-tip
-    el.add-event-listener \mouseout  hide-tip
+    tip
 
-
-
-  module?exports = tipsy
-  tipsy
+  module?exports = add-tip
+  add-tip

--- a/src/tipsy.ls
+++ b/src/tipsy.ls
@@ -10,6 +10,7 @@
 Tipsy = let
   
   d = document
+  de = d.document-element
 
   add-tip = !->
     it.add-event-listener \mouseover show-tip
@@ -48,8 +49,8 @@ Tipsy = let
     d.body.insert-before tip, d.body.first-child 
 
     el-rect = el.get-bounding-client-rect!
-    el-top  = el-rect.top + 1
-    el-left = el-rect.left
+    el-top  = el-rect.top + 1 + window.page-y-offset - de.client-top
+    el-left = el-rect.left + window.page-x-offset - de.client-left
 
     el-width  = el.offset-width
     el-height = el.offset-height

--- a/src/tipsy.ls
+++ b/src/tipsy.ls
@@ -2,15 +2,15 @@ Tipsy = let
   
   d = document
 
-  add-tip = ->
+  add-tip = !->
     it.add-event-listener \mouseover show-tip
     it.add-event-listener \mouseout  destroy-tip
 
-  show-tip = ->
+  show-tip = !->
     el = it.target.parent-node
-    tip = tipsy el
+    tipsy el
 
-  destroy-tip = ->
+  destroy-tip = !->
     tip = d.body.query-selector \.tipsy
     d.body.remove-child tip
 
@@ -19,7 +19,7 @@ Tipsy = let
     text: 'Live&nbsp;Preview'
     offset: 0
 
-  tipsy = (el, opts = ^^default-opts) ->
+  tipsy = (el, opts = ^^default-opts) !->
     
     tip = d.create-element \div
       ..class-name = "tipsy tipsy-#{opts.gravity}"
@@ -55,8 +55,6 @@ Tipsy = let
     tip.style
       ..top = pos.top + \px
       ..left = pos.left + \px
-
-    tip
 
   module?exports = add-tip
   add-tip

--- a/src/tipsy.ls
+++ b/src/tipsy.ls
@@ -8,7 +8,6 @@ Tipsy = let
 
   show-tip = ->
     el = it.target.parent-node
-    console.log el
     tip = tipsy el
 
   destroy-tip = ->
@@ -52,9 +51,6 @@ Tipsy = let
     | \s => top: el-top - tip-height - opts.offset, left: el-left + el-width / 2 - tip-width / 2
     | \e => top: el-top + el-height / 2 - tip-height / 2, left: el-left - tip-width - opts.offset
     | \w => top: el-top + el-height / 2 - tip-height / 2, left: el-left + el-width + opts.offset
-
-    console.log el-top, el-left, el-width, el-height, tip-width, tip-height
-    console.log pos
 
     tip.style
       ..top = pos.top + \px


### PR DESCRIPTION
Replaces the clunky inline gist embed with a lightweight clone of [**tipsy**](https://github.com/jaz303/tipsy).
